### PR TITLE
feat: make Slack/PagerDuty notifications optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ module "dnsmagic" {
   manage_instance_dns              = true
   private_instance_record_template = "service.instanceid.domain"
   manage_private_asg_dns           = true
+  # Optional notifications (enabled by default)
+  enable_slack                     = false
+  enable_pagerduty                 = false
   ttl                              = 60
 }
 
@@ -94,22 +97,24 @@ No modules.
 | <a name="input_asg_count"></a> [asg\_count](#input\_asg\_count) | Number of the Autoscaling Groups defined in asg\_names variable. Only here because count cannot be computed | `string` | `"1"` | no |
 | <a name="input_asg_names"></a> [asg\_names](#input\_asg\_names) | Name of the Autoscaling Groups to attach this Lambda Function to | `list(string)` | n/a | yes |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Enable or disable the Lambda DNS functionality. | `string` | `"1"` | no |
-| <a name="input_environment"></a> [environment](#input\_environment) | Environment | `string` | n/a | yes |
+| <a name="input_enable_pagerduty"></a> [enable\_pagerduty](#input\_enable\_pagerduty) | Enable PagerDuty incident creation from the Lambda. | `bool` | `true` | no |
+| <a name="input_enable_slack"></a> [enable\_slack](#input\_enable\_slack) | Enable Slack notifications from the Lambda. | `bool` | `true` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment | `string` | `""` | no |
 | <a name="input_lambda_function_name"></a> [lambda\_function\_name](#input\_lambda\_function\_name) | The name of the Lambda Function to create, which will manage the Autoscaling Groups | `string` | n/a | yes |
 | <a name="input_manage_instance_dns"></a> [manage\_instance\_dns](#input\_manage\_instance\_dns) | Whether to manage DNS records for Autoscaling Group instances | `bool` | `true` | no |
 | <a name="input_manage_private_asg_dns"></a> [manage\_private\_asg\_dns](#input\_manage\_private\_asg\_dns) | Whether to manage DNS records for private Autoscaling Group instances | `bool` | `false` | no |
 | <a name="input_manage_public_asg_dns"></a> [manage\_public\_asg\_dns](#input\_manage\_public\_asg\_dns) | Whether to manage DNS records for public Autoscaling Group instances | `bool` | `false` | no |
-| <a name="input_pd_escalation_policy"></a> [pd\_escalation\_policy](#input\_pd\_escalation\_policy) | PagerDuty Escalation Policy | `string` | n/a | yes |
-| <a name="input_pd_priority"></a> [pd\_priority](#input\_pd\_priority) | PagerDuty Priority ID | `string` | n/a | yes |
-| <a name="input_pd_service"></a> [pd\_service](#input\_pd\_service) | PagerDuty Service ID | `string` | n/a | yes |
-| <a name="input_pd_user_email"></a> [pd\_user\_email](#input\_pd\_user\_email) | PagerDuty Registered User Email | `string` | n/a | yes |
+| <a name="input_pd_escalation_policy"></a> [pd\_escalation\_policy](#input\_pd\_escalation\_policy) | PagerDuty Escalation Policy | `string` | `""` | no |
+| <a name="input_pd_priority"></a> [pd\_priority](#input\_pd\_priority) | PagerDuty Priority ID | `string` | `""` | no |
+| <a name="input_pd_service"></a> [pd\_service](#input\_pd\_service) | PagerDuty Service ID | `string` | `""` | no |
+| <a name="input_pd_user_email"></a> [pd\_user\_email](#input\_pd\_user\_email) | PagerDuty Registered User Email | `string` | `""` | no |
 | <a name="input_private_asg_record_template"></a> [private\_asg\_record\_template](#input\_private\_asg\_record\_template) | The fully qualified domain name format for private Autoscaling Group DNS records | `string` | `"service.internal.domain"` | no |
 | <a name="input_private_instance_record_template"></a> [private\_instance\_record\_template](#input\_private\_instance\_record\_template) | The fully qualified domain name format for private instance DNS records | `string` | `"service.az.domain"` | no |
 | <a name="input_public_asg_record_template"></a> [public\_asg\_record\_template](#input\_public\_asg\_record\_template) | The fully qualified domain name format for public Autoscaling Group DNS records | `string` | `"service.domain"` | no |
 | <a name="input_runtime"></a> [runtime](#input\_runtime) | Runtime binary | `string` | `"python3.12"` | no |
-| <a name="input_secret_name"></a> [secret\_name](#input\_secret\_name) | Daemon Secret Manager | `string` | n/a | yes |
+| <a name="input_secret_name"></a> [secret\_name](#input\_secret\_name) | Daemon Secret Manager | `string` | `""` | no |
 | <a name="input_service"></a> [service](#input\_service) | Autoscaling Group service name, e.g. 'bastion'. This will be prefix for DNS records. | `string` | n/a | yes |
-| <a name="input_slack_webhook"></a> [slack\_webhook](#input\_slack\_webhook) | slack webhook for notifications | `string` | n/a | yes |
+| <a name="input_slack_webhook"></a> [slack\_webhook](#input\_slack\_webhook) | slack webhook for notifications | `string` | `""` | no |
 | <a name="input_sns_topic_name"></a> [sns\_topic\_name](#input\_sns\_topic\_name) | Name for the SNS topic which will handle notifications of instance launch and terminate events | `string` | n/a | yes |
 | <a name="input_ttl"></a> [ttl](#input\_ttl) | TTL value for the DNS record(s) | `number` | `60` | no |
 | <a name="input_zone_id"></a> [zone\_id](#input\_zone\_id) | Id of a zone file to add records to | `string` | n/a | yes |

--- a/include/lambda.py
+++ b/include/lambda.py
@@ -13,13 +13,17 @@ from string import Template
 zone_id = os.environ['ZONE_ID']
 service = os.environ['SERVICE']
 ttl = int(os.environ['TTL'])
-webhook_url = os.environ['SLACK_WEBHOOK']
-environment = os.environ['ENVIRONMENT']
-secret_name = os.environ['SECRET_NAME']
-pd_service = os.environ['PD_SERVICE']
-pd_escalation_policy = os.environ['PD_ESCALATION_POLICY']
-pd_priority = os.environ['PD_PRIORITY']
-pd_user_email = os.environ['PD_USER_EMAIL']
+
+enable_slack = os.environ.get('ENABLE_SLACK', 'True').lower() in ["true", "1"]
+enable_pagerduty = os.environ.get('ENABLE_PAGERDUTY', 'True').lower() in ["true", "1"]
+
+webhook_url = os.environ.get('SLACK_WEBHOOK', '')
+environment = os.environ.get('ENVIRONMENT', '')
+secret_name = os.environ.get('SECRET_NAME', '')
+pd_service = os.environ.get('PD_SERVICE', '')
+pd_escalation_policy = os.environ.get('PD_ESCALATION_POLICY', '')
+pd_priority = os.environ.get('PD_PRIORITY', '')
+pd_user_email = os.environ.get('PD_USER_EMAIL', '')
 
 
 datestamp = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%f")
@@ -77,6 +81,9 @@ def generate_record_name(template, **kwargs):
 
 def slack_notification(message):
     try:
+        if not webhook_url:
+            print("Slack notifications enabled but SLACK_WEBHOOK is empty; skipping.")
+            return False
         slack_message = {'text': message}
 
         http = urllib3.PoolManager()
@@ -92,6 +99,8 @@ def slack_notification(message):
 
 
 def get_secret(secret_name):
+    if not secret_name:
+        raise Exception("SECRET_NAME is empty")
 
     session = boto3.session.Session()
     client = session.client(
@@ -215,23 +224,38 @@ def lambda_handler(event, context):
     # apply dns updates
     if changes:
         change_rrs(changes, zone_id)
-    slack_notification(f"{service} {environment} has restarted!!") 
-    
-    #PagerDuty Alert
-    data = json.loads(PD_DATA)
-    data = json.dumps(data)
-    data = data.encode()
-    http = urllib3.PoolManager()
-    secret_value = get_secret(secret_name)
-    new_secret_value = (secret_value['pager_duty_api_key'])
-    print("new_secret_value " + new_secret_value)
-    response = http.request('POST',
-        'https://api.pagerduty.com/incidents',
-        body = data,
-        headers = {'Content-Type': 'application/json','Accept': 'application/vnd.pagerduty+json;version=2','Authorization': 'Token token=' + str(new_secret_value) + '', 'From': '' + pd_user_email + ''},
-        retries = False)
-    content = response.read()
-    print(content)
+
+    if enable_slack:
+        slack_notification(f"{service} {environment} has restarted!!")
+
+    if enable_pagerduty:
+        if not (pd_service and pd_priority and pd_escalation_policy and pd_user_email):
+            print("PagerDuty notifications enabled but required PD_* env vars are missing; skipping.")
+            return
+
+        try:
+            data = json.loads(PD_DATA)
+            data = json.dumps(data)
+            data = data.encode()
+            http = urllib3.PoolManager()
+            secret_value = get_secret(secret_name)
+            new_secret_value = (secret_value['pager_duty_api_key'])
+            response = http.request(
+                'POST',
+                'https://api.pagerduty.com/incidents',
+                body=data,
+                headers={
+                    'Content-Type': 'application/json',
+                    'Accept': 'application/vnd.pagerduty+json;version=2',
+                    'Authorization': 'Token token=' + str(new_secret_value) + '',
+                    'From': '' + pd_user_email + ''
+                },
+                retries=False
+            )
+            content = response.read()
+            print(content)
+        except Exception:
+            traceback.print_exc()
 
 
 # helpers

--- a/include/lambda.py
+++ b/include/lambda.py
@@ -14,8 +14,8 @@ zone_id = os.environ['ZONE_ID']
 service = os.environ['SERVICE']
 ttl = int(os.environ['TTL'])
 
-enable_slack = os.environ.get('ENABLE_SLACK', 'True').lower() in ["true", "1"]
-enable_pagerduty = os.environ.get('ENABLE_PAGERDUTY', 'True').lower() in ["true", "1"]
+enable_slack = os.environ.get('ENABLE_SLACK', 'False')
+enable_pagerduty = os.environ.get('ENABLE_PAGERDUTY', 'False')
 
 webhook_url = os.environ.get('SLACK_WEBHOOK', '')
 environment = os.environ.get('ENVIRONMENT', '')

--- a/main.tf
+++ b/main.tf
@@ -25,8 +25,10 @@ resource "aws_lambda_function" "manage_dns" {
     variables = {
       ZONE_ID                          = var.zone_id
       SERVICE                          = var.service
+      ENABLE_SLACK                     = var.enable_slack ? "True" : "False"
       SLACK_WEBHOOK                    = var.slack_webhook
       ENVIRONMENT                      = var.environment
+      ENABLE_PAGERDUTY                 = var.enable_pagerduty ? "True" : "False"
       PD_SERVICE                       = var.pd_service
       PD_PRIORITY                      = var.pd_priority
       PD_ESCALATION_POLICY             = var.pd_escalation_policy

--- a/variables.tf
+++ b/variables.tf
@@ -74,38 +74,58 @@ variable "runtime" {
   default     = "python3.12"
 }
 
+# Notifications
+variable "enable_slack" {
+  description = "Enable Slack notifications from the Lambda."
+  type        = bool
+  default     = true
+}
+
+variable "enable_pagerduty" {
+  description = "Enable PagerDuty incident creation from the Lambda."
+  type        = bool
+  default     = true
+}
+
 #SD-2156
 variable "slack_webhook" {
   type        = string
   description = "slack webhook for notifications"
+  default     = ""
 }
 
 variable "environment" {
   type        = string
   description = "Environment"
+  default     = ""
 }
 
 variable "pd_service" {
   type        = string
   description = "PagerDuty Service ID"
+  default     = ""
 }
 
 variable "pd_priority" {
   type        = string
   description = "PagerDuty Priority ID"
+  default     = ""
 }
 
 variable "pd_escalation_policy" {
   type        = string
   description = "PagerDuty Escalation Policy"
+  default     = ""
 }
 
 variable "pd_user_email" {
   type        = string
   description = "PagerDuty Registered User Email"
+  default     = ""
 }
 
 variable "secret_name" {
   type        = string
   description = "Daemon Secret Manager"
+  default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -78,13 +78,13 @@ variable "runtime" {
 variable "enable_slack" {
   description = "Enable Slack notifications from the Lambda."
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "enable_pagerduty" {
   description = "Enable PagerDuty incident creation from the Lambda."
   type        = bool
-  default     = true
+  default     = false
 }
 
 #SD-2156


### PR DESCRIPTION
Add enable_slack/enable_pagerduty flags, relax required notification inputs, and guard Lambda notification calls so the module can be used for DNS updates without Slack/PD configuration.
